### PR TITLE
#7 fix(validation): endurecer regras de validação para o campo cargo

### DIFF
--- a/Project/src/middlewares/validateEmployee.ts
+++ b/Project/src/middlewares/validateEmployee.ts
@@ -18,9 +18,12 @@ const addEmployeeSchema = z.object({
 
   cargo: z
     .string({ required_error: "O campo 'cargo' é obrigatório." })
-    .min(1, { message: "O campo 'cargo' não pode estar vazio." })
+    .trim()
     .min(3, { message: "O cargo deve ter no mínimo 3 caracteres." })
-    .trim(),
+    .regex(/^[A-Za-zÀ-ÿ]+(?:\s+[A-Za-zÀ-ÿ]+)*$/, {
+      message:
+        "O cargo deve conter apenas letras (incluindo acentos) e espaços entre palavras.",
+    }),
 });
 
 // ── Tipo exportado para uso no Controller / Service ───────────────

--- a/Project/src/middlewares/validateUpdateEmployee.ts
+++ b/Project/src/middlewares/validateUpdateEmployee.ts
@@ -19,8 +19,12 @@ const updateEmployeeSchema = z.object({
 
   cargo: z
     .string()
-    .min(3, { message: "O cargo deve ter no mínimo 3 caracteres." })
     .trim()
+    .min(3, { message: "O cargo deve ter no mínimo 3 caracteres." })
+    .regex(/^[A-Za-zÀ-ÿ]+(?:\s+[A-Za-zÀ-ÿ]+)*$/, {
+      message:
+        "O cargo deve conter apenas letras (incluindo acentos) e espaços entre palavras.",
+    })
     .optional(),
 }).refine(
   (data) => data.nomeFunc || data.cargo,


### PR DESCRIPTION
issue: #7 
@victtorqueiroz 
**📖 Descrição / Motivação**
Identificamos que o campo `cargo` aceitava dados inconsistentes, como apenas números, símbolos ou espaços vazios. Este PR implementa uma validação robusta via Zod para garantir a integridade dos dados cadastrados.

**🛠️ O que foi feito**

* Atualização dos middlewares `validateEmployee` e `validateUpdateEmployee`.
* Uso de `.trim()` para limpar entradas.
* Implementação de Regex para validar nomes de cargos (apenas letras e acentos).
* Garantia de que a regra de `min(3)` seja aplicada após a limpeza dos espaços.

**🧪 Como testar**

1. Tente criar/editar um funcionário com `cargo: "   "`. Deve falhar por tamanho insuficiente.
2. Tente usar `cargo: "123"` ou `cargo: "#$%!"`. Deve falhar pela regra de caracteres permitidos.
3. Use um cargo válido como `"Mestre de Obras"`. Deve ser aceito normalmente.