### PR TITLE
#8 fix(auth): Impedir reutilização da senha atual na redefinição

### DIFF
--- a/Project/src/services/AuthService.ts
+++ b/Project/src/services/AuthService.ts
@@ -203,11 +203,20 @@ export class AuthService {
           gt: now,
         },
       },
-      select: { id: true },
+      select: { id: true, hashSenha: true },
     });
 
     if (!user) {
       throw new AuthenticationError("Token inválido ou expirado.");
+    }
+
+    // Validação de segurança: impedir reutilização da senha atual
+    const passwordIsSame = await bcryptjs.compare(input.password, user.hashSenha);
+
+    if (passwordIsSame) {
+      throw new AuthenticationError(
+        "A nova senha não pode ser igual à senha atual. Por favor, escolha uma senha diferente."
+      );
     }
 
     const hashedPassword = await bcryptjs.hash(input.password, BCRYPT_SALT_ROUNDS);


### PR DESCRIPTION
Issue: #8 
@victtorqueiroz 

### 📖 **Descrição / Motivação**

Identificamos uma brecha de segurança no fluxo de redefinição de senha (`/auth/reset-password`). O sistema permitia que os usuários alterassem suas senhas para a **exata mesma senha** que já estava ativa na conta. Para garantir as melhores práticas de segurança da informação e evitar falsas sensações de segurança (especialmente em suspeitas de vazamento), este PR bloqueia a reutilização da credencial atual.

### 🛠️ **O que foi feito**

* Atualização no serviço de autenticação (`src/services/AuthService.ts`).
* Adicionado o campo `hashSenha` no `select` do Prisma para resgatar a senha atual do usuário.
* Implementação da checagem via `bcryptjs.compare` entre a nova senha enviada no payload e o hash armazenado no banco de dados.
* Adição de lançamento de erro (`AuthenticationError`) resultando em um HTTP `400 Bad Request` com uma mensagem amigável caso as senhas coincidam.

### 🧪 **Como testar**

1. Faça uma requisição `POST` para `/auth/forgot-password` informando o e-mail de um usuário existente e copie o token gerado.
2. Faça uma requisição `POST` para `/auth/reset-password` passando o `token` e a **mesma senha** que o usuário já utiliza.
3. **Comportamento esperado (Bloqueio):** A API deve retornar status `400` com a mensagem: *"A nova senha não pode ser igual à senha atual. Por favor, escolha uma senha diferente."*
4. Repita a requisição do passo 2, mas agora enviando uma senha **nova e diferente**.
5. **Comportamento esperado (Sucesso):** A API deve retornar status `200 OK`, atualizando a senha com sucesso.

### ☑️ **Checklist**

* [x] O código segue os padrões do projeto.
* [x] Validação de segurança aplicada com sucesso no AuthService.
* [x] Testes manuais realizados com sucesso via Postman/Insomnia.

---