### PR TITLE
fix 07 S3(project): Impedir criação de projeto com número de ART duplicado

### DIFF
--- a/Project/src/services/ProjectService.ts
+++ b/Project/src/services/ProjectService.ts
@@ -82,6 +82,20 @@ export class ProjectService {
       );
     }
 
+    // 2. Verificar se a ART informada já pertence a outro projeto
+    if (data.art && data.art.trim() !== "") {
+      const existingProjectWithArt = await prisma.projeto.findFirst({
+        where: { art: data.art.trim() },
+        select: { idProjeto: true },
+      });
+
+      if (existingProjectWithArt) {
+        throw new ProjectCreationError(
+          "Já existe um projeto cadastrado com este número de ART."
+        );
+      }
+    }
+
     // 2. Inserir o Projeto no banco
     try {
       const projeto = await prisma.projeto.create({


### PR DESCRIPTION
**Título do PR:** `fix(project): Impedir criação de projeto com número de ART duplicado`

**📖 Descrição / Motivação**
Identificamos que o sistema permitia a criação de múltiplos projetos utilizando o mesmo número de Anotação de Responsabilidade Técnica (ART). Sendo a ART um identificador único de responsabilidade para cada obra, o comportamento gerava inconsistência no banco de dados. Este PR adiciona uma validação de unicidade antes da persistência do projeto.

**🛠️ O que foi feito**

* Inspecionado o `schema.prisma` para verificar a estrutura do campo `art`.
* Atualizado o método `createProject` dentro de `src/services/ProjectService.ts`.
* Adicionada uma consulta prévia (`prisma.project.findFirst`) buscando pela ART informada.
* Caso a ART já exista, a API interrompe o fluxo lançando um `ProjectCreationError`, que retorna HTTP `400 Bad Request` com uma mensagem clara para o usuário.

**🧪 Como testar**

1. Tente cadastrar um novo projeto informando uma ART inédita. O fluxo deve seguir normalmente (HTTP `201`).
2. Tente cadastrar outro projeto (pela interface ou Postman) enviando o **mesmo número de ART** utilizado no passo anterior.
3. **Comportamento esperado:** O sistema deve bloquear a operação e retornar o status `400` com o JSON:
```json
{
  "status": "error",
  "message": "Já existe um projeto cadastrado com este número de ART."
}

```
@victtorqueiroz 