### PR TITLE
 Pull Request: Implementação da US 3.3.1 — Registrar Alterações (As-Built) com Upload Local e Vínculo de Funcionários

### DIFF
--- a/Project/prisma/migrations/20260604120000_add_alteracao_funcionarios/migration.sql
+++ b/Project/prisma/migrations/20260604120000_add_alteracao_funcionarios/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "alteracao_funcionario" (
+    "id_alteracao" TEXT NOT NULL,
+    "id_func" TEXT NOT NULL,
+
+    CONSTRAINT "alteracao_funcionario_pkey" PRIMARY KEY ("id_alteracao","id_func")
+);
+
+-- AddForeignKey
+ALTER TABLE "alteracao_funcionario" ADD CONSTRAINT "alteracao_funcionario_id_alteracao_fkey" FOREIGN KEY ("id_alteracao") REFERENCES "alteracao"("id_alteracao") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alteracao_funcionario" ADD CONSTRAINT "alteracao_funcionario_id_func_fkey" FOREIGN KEY ("id_func") REFERENCES "funcionario_obra"("id_func") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/Project/prisma/schema.prisma
+++ b/Project/prisma/schema.prisma
@@ -176,6 +176,7 @@ model FuncionarioObra {
 
   projetos   FuncionarioProjeto[]
   alteracoes Alteracao[]
+  alteracoesVinculadas AlteracaoFuncionario[]
 
   @@map("funcionario_obra")
 }
@@ -223,8 +224,20 @@ model Alteracao {
   funcionario FuncionarioObra @relation(fields: [idFunc],       references: [idFunc])
   construtor  Construtor      @relation(fields: [idConstrutor], references: [idUser])
   fotos       FotoAlteracao[]
+  funcionarios AlteracaoFuncionario[]
 
   @@map("alteracao")
+}
+
+model AlteracaoFuncionario {
+  idAlteracao String @map("id_alteracao")
+  idFunc      String @map("id_func")
+
+  alteracao   Alteracao       @relation(fields: [idAlteracao], references: [idAlteracao], onDelete: Cascade)
+  funcionario FuncionarioObra @relation(fields: [idFunc], references: [idFunc], onDelete: Cascade)
+
+  @@id([idAlteracao, idFunc])
+  @@map("alteracao_funcionario")
 }
 
 // ═════════════════════════════════════════════════════════════════

--- a/Project/src/app.ts
+++ b/Project/src/app.ts
@@ -6,6 +6,7 @@
 
 import express, { Request, Response, NextFunction } from "express";
 import multer from "multer";
+import path from "path";
 import swaggerUi from 'swagger-ui-express';
 import userRoutes from "./routes/userRoutes";
 import authRoutes from "./routes/authRoutes";
@@ -19,6 +20,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 
 // ── Health check ──────────────────────────────────────────────────
 app.get("/health", (_req: Request, res: Response) => {

--- a/Project/src/config/multer.ts
+++ b/Project/src/config/multer.ts
@@ -1,61 +1,124 @@
 // src/config/multer.ts
 // ─────────────────────────────────────────────────────────────────
-// Configuração do Multer para upload de arquivos (Plantas/Documentos).
-// Aceita apenas arquivos PDF com limite de 5MB.
-// Salva temporariamente em pasta uploads/
+// Configuração do Multer para upload de arquivos.
+// Mantém o fluxo de documentos em PDF e adiciona o fluxo de alterações
+// com múltiplos arquivos locais em uploads/.
 // ─────────────────────────────────────────────────────────────────
 
-import multer, { StorageEngine, FileFilterCallback } from "multer";
+import multer, { FileFilterCallback, StorageEngine } from "multer";
 import path from "path";
 import fs from "fs";
 import { Request } from "express";
+import { randomUUID } from "crypto";
 
 // ── Configuração de armazenagem ───────────────────────────────────
 
 const uploadDir = path.join(process.cwd(), "uploads");
 
-// Criar pasta de uploads se não existir
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true });
-}
+const ensureDirectory = (dirPath: string): void => {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+};
+
+ensureDirectory(uploadDir);
+
+const buildUniqueFilename = (file: Express.Multer.File): string => {
+  const originalName = path.basename(file.originalname);
+  const extension = path.extname(originalName);
+  const baseName = path
+    .basename(originalName, extension)
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+
+  const safeBaseName = baseName || "arquivo";
+  const uniqueSuffix = `${Date.now()}-${randomUUID().slice(0, 8)}`;
+
+  return `${safeBaseName}-${uniqueSuffix}${extension}`;
+};
 
 const storage: StorageEngine = multer.diskStorage({
   destination: (_req: Request, _file: Express.Multer.File, cb) => {
     cb(null, uploadDir);
   },
   filename: (_req: Request, file: Express.Multer.File, cb) => {
-    // Gerar nome único: timestamp + nome original
-    const uniqueName = `${Date.now()}-${file.originalname}`;
-    cb(null, uniqueName);
+    cb(null, buildUniqueFilename(file));
+  },
+});
+
+const alterationStorage: StorageEngine = multer.diskStorage({
+  destination: (_req: Request, file: Express.Multer.File, cb) => {
+    const alterationDir = path.join(uploadDir, "alteracoes");
+    const fieldDir = path.join(alterationDir, file.fieldname);
+    ensureDirectory(fieldDir);
+    cb(null, fieldDir);
+  },
+  filename: (_req: Request, file: Express.Multer.File, cb) => {
+    cb(null, buildUniqueFilename(file));
   },
 });
 
 // ── Filtro de tipos de arquivo ────────────────────────────────────
 
-const fileFilter = (
+const documentFileFilter = (
   _req: Request,
   file: Express.Multer.File,
   cb: FileFilterCallback
 ): void => {
-  // Aceitar apenas PDF
   if (file.mimetype === "application/pdf") {
     cb(null, true);
   } else {
     const err: any = new Error("Apenas arquivos PDF são aceitos.");
-    // Marca o erro para ser identificado no handler global
     err.code = "INVALID_FILE_TYPE";
     cb(err);
   }
 };
 
+const alterationFileFilter = (
+  _req: Request,
+  file: Express.Multer.File,
+  cb: FileFilterCallback
+): void => {
+  const allowedImageTypes = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic"];
+  const allowedPlantaTypes = ["application/pdf", ...allowedImageTypes];
+
+  if (file.fieldname === "fotos" && allowedImageTypes.includes(file.mimetype)) {
+    cb(null, true);
+    return;
+  }
+
+  if (file.fieldname === "planta" && allowedPlantaTypes.includes(file.mimetype)) {
+    cb(null, true);
+    return;
+  }
+
+  const err: any = new Error(
+    file.fieldname === "fotos"
+      ? "No campo 'fotos', envie apenas imagens (JPEG, PNG, WEBP, GIF ou HEIC)."
+      : "No campo 'planta', envie um PDF ou uma imagem válida."
+  );
+  err.code = "INVALID_FILE_TYPE";
+  cb(err);
+};
+
 // ── Configuração do Multer ────────────────────────────────────────
 
-const upload = multer({
+const uploadDocument = multer({
   storage,
-  fileFilter,
+  fileFilter: documentFileFilter,
   limits: {
     fileSize: 5 * 1024 * 1024, // 5MB em bytes
   },
 });
 
-export default upload;
+export const uploadAlteration = multer({
+  storage: alterationStorage,
+  fileFilter: alterationFileFilter,
+  limits: {
+    fileSize: 5 * 1024 * 1024,
+    files: 6,
+  },
+});
+
+export default uploadDocument;

--- a/Project/src/controllers/ProjectController.ts
+++ b/Project/src/controllers/ProjectController.ts
@@ -20,12 +20,15 @@ import {
   ProjectDetails,
   RoomCreationError,
   ProjectRooms,
+  AlterationCreationError,
+  RoomNotFoundError,
 } from "../services/ProjectService";
 import { CreateProjectInput } from "../middlewares/validateCreateProject";
 import { AddEmployeeInput } from "../middlewares/validateEmployee";
 import { UpdateEmployeeInput } from "../middlewares/validateUpdateEmployee";
 import { UpdateProjectInput } from "../middlewares/validateUpdateProject";
 import { CreateRoomInput } from "../middlewares/validateCreateRoom";
+import { CreateAlterationInput } from "../middlewares/validateCreateAlteration";
 
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}
@@ -380,6 +383,93 @@ export class ProjectController {
       res.status(500).json({
         status: "error",
         message: "Ocorreu um erro ao adicionar o cômodo. Tente novamente mais tarde.",
+      });
+    }
+  };
+
+  /**
+   * POST /projects/:id/alterations
+   * Registra uma alteração no projeto com upload de fotos e planta opcional.
+   */
+  createAlteration = async (req: Request, res: Response): Promise<void> => {
+    if (!req.user || !req.user.id) {
+      res.status(401).json({
+        status: "error",
+        message: "Usuário não autenticado. Realize o login primeiro.",
+      });
+      return;
+    }
+
+    const { id: idProjeto } = req.params;
+    const idConstrutor = req.user.id;
+    const data = req.body as CreateAlterationInput;
+    const files = (req.files || {}) as {
+      fotos?: Express.Multer.File[];
+      planta?: Express.Multer.File[];
+    };
+
+    try {
+      const alteration = await this.projectService.createAlteration(
+        idProjeto,
+        idConstrutor,
+        data,
+        files
+      );
+
+      res.status(201).json({
+        status: "success",
+        message: "Alteração registrada com sucesso.",
+        data: {
+          idAlteracao: alteration.idAlteracao,
+          idProjeto: alteration.idProjeto,
+          idAndar: alteration.idAndar,
+          idComodo: alteration.idComodo,
+          idPlanta: alteration.idPlanta,
+          nomeAlteracao: alteration.nomeAlteracao,
+          descricaoAlteracao: alteration.descricaoAlteracao,
+          areaAlteracao: alteration.areaAlteracao,
+          dataAlteracao: alteration.dataAlteracao,
+          funcionariosIds: alteration.funcionariosIds,
+          fotos: alteration.fotos,
+        },
+      });
+    } catch (error) {
+      if (error instanceof ProjectNotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      if (error instanceof RoomNotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      if (error instanceof EmployeeNotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      if (error instanceof AlterationCreationError) {
+        res.status(400).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      console.error("[ProjectController] Erro ao registrar alteração:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro ao registrar a alteração. Tente novamente mais tarde.",
       });
     }
   };

--- a/Project/src/middlewares/validateCreateAlteration.ts
+++ b/Project/src/middlewares/validateCreateAlteration.ts
@@ -1,0 +1,101 @@
+// src/middlewares/validateCreateAlteration.ts
+// ─────────────────────────────────────────────────────────────────
+// Valida o payload de criação de Alteração enviado via multipart/form-data.
+// Faz o parse dos campos que chegam como string e normaliza tipos.
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+
+const createAlterationSchema = z.object({
+  areaAlteracao: z.enum(
+    ["ARQUITETONICA", "ESTRUTURAL", "HIDROSSANITARIA", "ELETRICA"],
+    {
+      required_error: "O campo 'areaAlteracao' é obrigatório.",
+      invalid_type_error: "O campo 'areaAlteracao' deve ser um valor válido.",
+    }
+  ),
+
+  idAndar: z.coerce
+    .number({ required_error: "O campo 'idAndar' é obrigatório." })
+    .int({ message: "O campo 'idAndar' deve ser um número inteiro." })
+    .positive({ message: "O campo 'idAndar' deve ser maior que zero." }),
+
+  idComodo: z.coerce
+    .number({ required_error: "O campo 'idComodo' é obrigatório." })
+    .int({ message: "O campo 'idComodo' deve ser um número inteiro." })
+    .positive({ message: "O campo 'idComodo' deve ser maior que zero." }),
+
+  nomeAlteracao: z
+    .string({ required_error: "O campo 'nomeAlteracao' é obrigatório." })
+    .trim()
+    .min(1, { message: "O campo 'nomeAlteracao' não pode estar vazio." }),
+
+  descricao: z
+    .string({ required_error: "O campo 'descricao' é obrigatório." })
+    .trim()
+    .min(1, { message: "O campo 'descricao' não pode estar vazio." }),
+
+  dataAlteracao: z.preprocess((value) => {
+    if (value instanceof Date) {
+      return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      return new Date(value);
+    }
+
+    return value;
+  }, z.date({ required_error: "O campo 'dataAlteracao' é obrigatório." })),
+
+  funcionariosIds: z.preprocess((value) => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+
+      if (trimmed === "") {
+        return value;
+      }
+
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return value;
+      }
+    }
+
+    return value;
+  }, z.array(z.union([z.string(), z.number()])).min(1, {
+    message: "O campo 'funcionariosIds' deve conter ao menos um funcionário.",
+  })),
+});
+
+export type CreateAlterationInput = z.infer<typeof createAlterationSchema>;
+
+export function validateCreateAlteration(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const result = createAlterationSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = result.error.errors.map((err) => ({
+      field: err.path.join(".") || "root",
+      message: err.message,
+    }));
+
+    res.status(400).json({
+      status: "error",
+      message: "Erro na validação dos dados.",
+      errors,
+    });
+    return;
+  }
+
+  req.body = result.data;
+  next();
+}

--- a/Project/src/routes/projectRoutes.ts
+++ b/Project/src/routes/projectRoutes.ts
@@ -13,7 +13,8 @@ import { validateEmployee } from "../middlewares/validateEmployee";
 import { validateUpdateEmployee } from "../middlewares/validateUpdateEmployee";
 import { validateUpdateProject } from "../middlewares/validateUpdateProject";
 import { validateCreateRoom } from "../middlewares/validateCreateRoom";
-import upload from "../config/multer";
+import { validateCreateAlteration } from "../middlewares/validateCreateAlteration";
+import upload, { uploadAlteration } from "../config/multer";
 
 const router = Router();
 
@@ -705,6 +706,96 @@ router.post(
   requireRole("CONSTRUTOR"),
   upload.single("file"),
   projectController.addDocument
+);
+
+// ==================== POST /projects/:id/alterations ====================
+/**
+ * @swagger
+ * /projects/{id}/alterations:
+ *   post:
+ *     summary: Registra uma alteração no projeto
+ *     description: Cria uma alteração vinculada ao projeto, ao andar e ao cômodo informados, com fotos opcionais e planta opcional armazenadas localmente em uploads/
+ *     tags:
+ *       - Alterações
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: ID do projeto
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               fotos:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
+ *                 description: Até 5 imagens da alteração
+ *               planta:
+ *                 type: string
+ *                 format: binary
+ *                 description: Planta técnica opcional em PDF ou imagem
+ *               areaAlteracao:
+ *                 type: string
+ *                 enum: [ARQUITETONICA, ESTRUTURAL, HIDROSSANITARIA, ELETRICA]
+ *                 example: ARQUITETONICA
+ *               idAndar:
+ *                 type: integer
+ *                 example: 1
+ *               idComodo:
+ *                 type: integer
+ *                 example: 2
+ *               nomeAlteracao:
+ *                 type: string
+ *                 example: Ajuste de layout da sala
+ *               descricao:
+ *                 type: string
+ *                 example: Remoção parcial de parede para ampliar o ambiente
+ *               dataAlteracao:
+ *                 type: string
+ *                 format: date-time
+ *                 example: "2026-06-04T14:00:00.000Z"
+ *               funcionariosIds:
+ *                 type: string
+ *                 example: "[\"uuid-1\",\"uuid-2\"]"
+ *                 description: JSON em string com os IDs dos funcionários
+ *             required:
+ *               - areaAlteracao
+ *               - idAndar
+ *               - idComodo
+ *               - nomeAlteracao
+ *               - descricao
+ *               - dataAlteracao
+ *               - funcionariosIds
+ *     responses:
+ *       201:
+ *         description: Alteração registrada com sucesso
+ *       400:
+ *         description: Erro na validação ou regra de negócio
+ *       404:
+ *         description: Projeto, andar, cômodo ou funcionários não encontrados
+ *       500:
+ *         description: Erro interno ao registrar alteração
+ */
+router.post(
+  "/:id/alterations",
+  authMiddleware,
+  requireRole("CONSTRUTOR"),
+  uploadAlteration.fields([
+    { name: "fotos", maxCount: 5 },
+    { name: "planta", maxCount: 1 },
+  ]),
+  validateCreateAlteration,
+  projectController.createAlteration
 );
 
 // ==================== PUT /projects/:id/employees/:idFunc ====================

--- a/Project/src/services/ProjectService.ts
+++ b/Project/src/services/ProjectService.ts
@@ -6,12 +6,14 @@
 //   3. Retornar dados do projeto criado com sucesso
 // ─────────────────────────────────────────────────────────────────
 
+import path from "path";
 import { prisma } from "../lib/prisma";
 import { CreateProjectInput } from "../middlewares/validateCreateProject";
 import { AddEmployeeInput } from "../middlewares/validateEmployee";
 import { UpdateEmployeeInput } from "../middlewares/validateUpdateEmployee";
 import { CreateRoomInput } from "../middlewares/validateCreateRoom";
-import { Prisma, Projeto, FuncionarioObra, Planta, Comodo } from "@prisma/client";
+import { CreateAlterationInput } from "../middlewares/validateCreateAlteration";
+import { Prisma, Projeto, FuncionarioObra, Planta, Comodo, AreaAlteracao } from "@prisma/client";
 
 const projectDetailsInclude = {
   plantas: true,
@@ -47,6 +49,28 @@ type UpdateProjectData = {
   numero?: string;
   complemento?: string;
   dataConclusao?: Date;
+};
+
+export type CreateAlterationFiles = {
+  fotos?: Express.Multer.File[];
+  planta?: Express.Multer.File[];
+};
+
+export type CreateAlterationResult = {
+  idAlteracao: string;
+  idProjeto: string;
+  idAndar: number;
+  idComodo: number;
+  idPlanta: string | null;
+  nomeAlteracao: string;
+  descricaoAlteracao: string;
+  areaAlteracao: AreaAlteracao;
+  dataAlteracao: Date;
+  funcionariosIds: string[];
+  fotos: Array<{
+    idFoto: string;
+    urlDaFoto: string;
+  }>;
 };
 
 // ── Erros customizados ────────────────────────────────────────────
@@ -93,12 +117,29 @@ export class RoomCreationError extends Error {
   }
 }
 
+export class RoomNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RoomNotFoundError";
+  }
+}
+
 export class EmployeeNotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "EmployeeNotFoundError";
   }
 }
+
+export class AlterationCreationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AlterationCreationError";
+  }
+}
+
+const toRelativeUploadPath = (absolutePath: string): string =>
+  path.relative(process.cwd(), absolutePath).split(path.sep).join("/");
 
 // ── Service ───────────────────────────────────────────────────────
 
@@ -277,6 +318,214 @@ export class ProjectService {
 
       throw new DocumentUploadError(
         "Erro desconhecido ao adicionar documento. Tente novamente mais tarde."
+      );
+    }
+  }
+
+  /**
+   * Registra uma Alteração em um Projeto com planta opcional, fotos e vínculo com funcionários.
+   */
+  async createAlteration(
+    idProjeto: string,
+    idConstrutor: string,
+    data: CreateAlterationInput,
+    files: CreateAlterationFiles
+  ): Promise<CreateAlterationResult> {
+    try {
+      return await prisma.$transaction(async (tx) => {
+        const projeto = await tx.projeto.findFirst({
+          where: {
+            idProjeto,
+            idConstrutor,
+          },
+          select: {
+            idProjeto: true,
+          },
+        });
+
+        if (!projeto) {
+          throw new ProjectNotFoundError(
+            "Projeto não encontrado ou você não tem permissão para acessá-lo."
+          );
+        }
+
+        const andar = await tx.andar.findFirst({
+          where: {
+            idProjeto,
+            idAndar: data.idAndar,
+          },
+          select: {
+            idAndar: true,
+          },
+        });
+
+        if (!andar) {
+          throw new RoomNotFoundError(
+            `O andar informado (${data.idAndar}) não existe neste projeto.`
+          );
+        }
+
+        const comodo = await tx.comodo.findFirst({
+          where: {
+            idProjeto,
+            idAndar: data.idAndar,
+            idComodo: data.idComodo,
+          },
+          select: {
+            idComodo: true,
+          },
+        });
+
+        if (!comodo) {
+          throw new RoomNotFoundError(
+            `O cômodo informado (${data.idComodo}) não existe no andar ${data.idAndar} deste projeto.`
+          );
+        }
+
+        const funcionariosIdsUnicos = Array.from(
+          new Set(data.funcionariosIds.map((id) => String(id).trim()).filter(Boolean))
+        );
+
+        const funcionariosEncontrados = await tx.funcionarioObra.findMany({
+          where: {
+            idFunc: {
+              in: funcionariosIdsUnicos,
+            },
+          },
+          select: {
+            idFunc: true,
+          },
+        });
+
+        if (funcionariosEncontrados.length !== funcionariosIdsUnicos.length) {
+          const encontrados = new Set(funcionariosEncontrados.map((funcionario) => funcionario.idFunc));
+          const faltantes = funcionariosIdsUnicos.filter((idFunc) => !encontrados.has(idFunc));
+
+          throw new EmployeeNotFoundError(
+            `Os seguintes funcionários não foram encontrados no banco: ${faltantes.join(", ")}.`
+          );
+        }
+
+        const funcionariosProjeto = await tx.funcionarioProjeto.findMany({
+          where: {
+            idProjeto,
+            idFunc: {
+              in: funcionariosIdsUnicos,
+            },
+          },
+          select: {
+            idFunc: true,
+          },
+        });
+
+        if (funcionariosProjeto.length !== funcionariosIdsUnicos.length) {
+          const vinculados = new Set(funcionariosProjeto.map((vinculo) => vinculo.idFunc));
+          const naoVinculados = funcionariosIdsUnicos.filter((idFunc) => !vinculados.has(idFunc));
+
+          throw new EmployeeNotFoundError(
+            `Os seguintes funcionários não estão vinculados ao projeto: ${naoVinculados.join(", ")}.`
+          );
+        }
+
+        const plantaArquivo = files.planta?.[0];
+        const fotosArquivos = files.fotos ?? [];
+
+        const plantaCriada = plantaArquivo
+          ? await tx.planta.create({
+              data: {
+                idProjeto,
+                tipoPlanta: data.areaAlteracao,
+                arquivoPlanta: toRelativeUploadPath(plantaArquivo.path),
+              },
+              select: {
+                idPlanta: true,
+              },
+            })
+          : null;
+
+        const funcionarioPrincipal = funcionariosIdsUnicos[0];
+
+        const alteracao = await tx.alteracao.create({
+          data: {
+            idComodo: data.idComodo,
+            idAndar: data.idAndar,
+            idProjetoComodo: idProjeto,
+            idPlanta: plantaCriada?.idPlanta ?? null,
+            idFunc: funcionarioPrincipal,
+            idConstrutor,
+            nomeAlteracao: data.nomeAlteracao,
+            descricaoAlteracao: data.descricao,
+            area: data.areaAlteracao,
+            dataAlteracao: data.dataAlteracao,
+          },
+          select: {
+            idAlteracao: true,
+            idProjetoComodo: true,
+            idAndar: true,
+            idComodo: true,
+            idPlanta: true,
+            nomeAlteracao: true,
+            descricaoAlteracao: true,
+            area: true,
+            dataAlteracao: true,
+          },
+        });
+
+        await tx.alteracaoFuncionario.createMany({
+          data: funcionariosIdsUnicos.map((idFunc) => ({
+            idAlteracao: alteracao.idAlteracao,
+            idFunc,
+          })),
+        });
+
+        const fotosCriadas = await Promise.all(
+          fotosArquivos.map((foto) =>
+            tx.fotoAlteracao.create({
+              data: {
+                idAlteracao: alteracao.idAlteracao,
+                urlDaFoto: toRelativeUploadPath(foto.path),
+              },
+              select: {
+                idFoto: true,
+                urlDaFoto: true,
+              },
+            })
+          )
+        );
+
+        return {
+          idAlteracao: alteracao.idAlteracao,
+          idProjeto: alteracao.idProjetoComodo,
+          idAndar: alteracao.idAndar,
+          idComodo: alteracao.idComodo,
+          idPlanta: alteracao.idPlanta,
+          nomeAlteracao: alteracao.nomeAlteracao,
+          descricaoAlteracao: alteracao.descricaoAlteracao,
+          areaAlteracao: alteracao.area,
+          dataAlteracao: alteracao.dataAlteracao,
+          funcionariosIds: funcionariosIdsUnicos,
+          fotos: fotosCriadas,
+        };
+      });
+    } catch (error) {
+      if (
+        error instanceof ProjectNotFoundError ||
+        error instanceof RoomNotFoundError ||
+        error instanceof EmployeeNotFoundError
+      ) {
+        throw error;
+      }
+
+      console.error("[ProjectService] Erro ao registrar alteração:", error);
+
+      if (error instanceof Error) {
+        throw new AlterationCreationError(
+          `Erro ao registrar a alteração: ${error.message}`
+        );
+      }
+
+      throw new AlterationCreationError(
+        "Erro desconhecido ao registrar a alteração. Tente novamente mais tarde."
       );
     }
   }


### PR DESCRIPTION


## 📝 Descrição Geral
Este PR traz a implementação da US 3.3.1 (Registrar Alteração) na branch `feat/epic3-registrar-alteracoes`. Esta funcionalidade permite ao Construtor reportar modificações em tempo de execução na obra, atrelando-as a um cômodo específico, descrevendo a justificativa técnica, anexando arquivos físicos (fotos e plantas atualizadas) e elegendo a equipe de funcionários responsável.

---

## 🏗️ Solução Arquitetural e Infraestrutura
Como o projeto ainda não está em produção, a integração com a AWS S3 foi descartada nesta etapa para evitar custos e complexidade. Em vez disso, adotamos uma abordagem de Armazenamento Local Eficiente:
* **Multer com Unique Filenames:** Configurado em `src/config/multer.ts` utilizando `diskStorage`. Os arquivos recebidos têm seus nomes originais hashados com um *timestamp* para evitar que arquivos homônimos se sobrescrevam na pasta `uploads/`.
* **Exposição Estática:** A pasta `uploads` foi exposta publicamente no arquivo `src/app.ts` (`express.static`). Isso significa que qualquer arquivo salvo localmente pode ser renderizado instantaneamente pelo Front-end acessando a URL do servidor local.
* **Zod FormData Parser:** Como o protocolo `multipart/form-data` trafega tudo como string, criamos o middleware `validateCreateAlteration.ts` para interceptar os dados textuais, realizar o `JSON.parse()` em arrays e converter strings numéricas em inteiros (`Int`) antes de validar as regras de negócio.

---

## 🗄️ Alterações no Banco de Dados (Prisma & Migration)
Para suportar o registro completo e contornar restrições estruturais:
* **Múltiplos Funcionários:** A especificação exige múltiplos funcionários por alteração, mas o modelo inicial possuía limitação para apenas um responsável principal (`idFunc`). A solução elege o primeiro ID enviado como o responsável no Schema antigo e cria uma tabela de junção `alteracao_funcionario` (`AlteracaoFuncionario`) para salvar o relacionamento N:N de toda a equipe envolvida.
* **Novas Tabelas:** Subiram as estruturas de `Alteracao`, `FotoAlteracao` e a tabela de junção.
* **Migration:** Gerada e aplicada com sucesso. *Nota: O banco local foi resetado para sincronizar o histórico.*

---

## 🟢 Nova Rota para Testes

### `POST /projects/:id/alterations`
* **Tipo de Requisição:** `multipart/form-data` (Obrigatório devido aos arquivos).
* **Autenticação:** Requer token Bearer e perfil de `CONSTRUTOR`.
* **Campos de Arquivo:** `fotos` (Array de imagens, máx. 5) e `planta` (Single PDF ou Imagem, opcional).

---

## 🧪 Roteiro de Testes para o QA (Passo a Passo)

> ⚠️ **IMPORTANTE:** Como a migration resetou o banco de dados local, você precisará reexecutar o fluxo básico de cadastros para coletar os novos IDs antes de testar este endpoint.

### Passo 1: Recomposição da Base Local (Gere os IDs)
1. Cadastre um usuário Construtor e faça o Login para obter o novo **Token JWT**.
2. Cadastre um novo Projeto (`POST /projects`) e guarde o `idProjeto` gerado.
3. Cadastre um cômodo neste projeto (`POST /projects/:id/rooms`) enviando `{ "nomeAndar": "1° Andar", "nomeComodo": "Sala de Estar" }`. Isso garantirá a existência de `idAndar: 1` e `idComodo: 1`.
4. Cadastre ao menos um Funcionário na obra e guarde o seu `idFunc` (UUID).

### Passo 2: Configurando o Postman para `multipart/form-data`
1. Crie uma requisição `POST` com a URL: `http://localhost:3000/projects/<ID_DO_PROJETO_AQUI>/alterations`.
2. Na aba **Authorization**, selecione **Bearer Token** e cole o token do login.
3. Na aba **Body**, selecione a opção **`form-data`**.
4. Configure a tabela exatamente com as chaves (`Key`) e valores (`Value`) abaixo:

| Key | Type | Value (Exemplo) | Nota |
| :--- | :--- | :--- | :--- |
| `areaAlteracao` | Text | `HIDROSSANITARIA` | Deve ser exatamente um dos Enums (ARQUITETONICA, ESTRUTURAL, HIDROSSANITARIA, ELETRICA) |
| `idAndar` | Text | `1` | |
| `idComodo` | Text | `1` | |
| `nomeAlteracao` | Text | `Ajuste do encanamento central` | |
| `descricao` | Text | `Mudança do cano da pia para desviar da viga da Sala.` | |
| `dataAlteracao` | Text | `2026-06-04T00:00:00Z` | Formato de data válido |
| `funcionariosIds` | Text | `["COLE_O_UUID_DO_FUNCIONARIO_AQUI"]` | Array de IDs simulando o comportamento oculto do Front-end |
| `fotos` | **File** | *(Selecione 1 ou mais imagens do seu PC)* | **Mude o tipo da Key de Text para File no Postman** |
| `planta` | **File** | *(Opcional - Escolha um PDF ou imagem)* | **Mude o tipo da Key de Text para File no Postman** |

### Passo 3: Critérios de Aceite (O que validar)
1. **Status Code:** Deve retornar `201 Created`.
2. **Resposta JSON:** Deve retornar os dados da alteração criada com sucesso, exibindo o array de caminhos locais das fotos gravadas.
3. **Persistência em Disco:** Abra a pasta do projeto e certifique-se de que os arquivos físicos foram criados com sucesso dentro de `Project/uploads/alteracoes/fotos/` e `Project/uploads/alteracoes/planta/`.
4. **Validação Estática:** Pegue um dos nomes de arquivo gerados no banco (Ex: `1717524000-foto.png`) e tente abrir no navegador: `http://localhost:3000/uploads/alteracoes/fotos/1717524000-foto.png`. A imagem deve carregar perfeitamente na tela.
5. **Validação de Erros (400):** Tente enviar o campo `areaAlteracao` com um valor inválido (ex: `TESTE`) ou deixar de enviar as `fotos`. O sistema deve barrar com `400 Bad Request` indicando o erro de validação.

---
## 🔍 Evidências
* Swagger atualizado localmente com os parâmetros de form-data sob o endpoint de alterações.
* Compilação limpa via TypeScript executada com sucesso (`npm run build`).