### PR TITLE
Feature: Módulo "Minha Conta" (API)

### DIFF
--- a/Project/src/controllers/MinhaContaController.ts
+++ b/Project/src/controllers/MinhaContaController.ts
@@ -1,0 +1,138 @@
+// src/controllers/MinhaContaController.ts
+// ─────────────────────────────────────────────────────────────────
+// Responsabilidades:
+//   1. Extrair userId de req.user (injetado pelo authMiddleware)
+//   2. Extrair body já validado pelos middlewares Zod
+//   3. Invocar MinhaContaService e mapear erros → respostas HTTP
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response } from "express";
+import {
+  MinhaContaService,
+  NotFoundError,
+  ConflictMinhaContaError,
+  InvalidCredentialsError,
+} from "../services/MinhaContaService";
+import { UpdateProfileInput, ChangePasswordInput } from "../middlewares/validateMinhaConta";
+
+export class MinhaContaController {
+  constructor(private readonly minhaContaService: MinhaContaService) {}
+
+  // ================================================================
+  // GET /users/me
+  // ================================================================
+
+  getMe = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user!.id;
+
+    try {
+      const profile = await this.minhaContaService.getMe(userId);
+
+      res.status(200).json({
+        status: "success",
+        message: "Perfil carregado com sucesso.",
+        data: { user: profile },
+      });
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      console.error("[MinhaContaController.getMe] Erro inesperado:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro interno. Tente novamente mais tarde.",
+      });
+    }
+  };
+
+  // ================================================================
+  // PATCH /users/me/profile
+  // ================================================================
+
+  updateProfile = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user!.id;
+    const input = req.body as UpdateProfileInput;
+
+    try {
+      const updated = await this.minhaContaService.updateProfile(userId, input);
+
+      res.status(200).json({
+        status: "success",
+        message: "Perfil atualizado com sucesso.",
+        data: { user: updated },
+      });
+    } catch (error) {
+      // ── E-mail já em uso por outro usuário ───────────────────────
+      if (error instanceof ConflictMinhaContaError) {
+        res.status(409).json({
+          status: "error",
+          message: error.message,
+          errors: { [error.field]: error.message },
+        });
+        return;
+      }
+
+      // ── Usuário não encontrado ────────────────────────────────────
+      if (error instanceof NotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      console.error("[MinhaContaController.updateProfile] Erro inesperado:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro interno. Tente novamente mais tarde.",
+      });
+    }
+  };
+
+  // ================================================================
+  // PATCH /users/me/password
+  // ================================================================
+
+  changePassword = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user!.id;
+    const input = req.body as ChangePasswordInput;
+
+    try {
+      await this.minhaContaService.changePassword(userId, input);
+
+      res.status(200).json({
+        status: "success",
+        message: "Senha alterada com sucesso.",
+      });
+    } catch (error) {
+      // ── Senha atual incorreta ─────────────────────────────────────
+      if (error instanceof InvalidCredentialsError) {
+        res.status(400).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      // ── Usuário não encontrado ────────────────────────────────────
+      if (error instanceof NotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      console.error("[MinhaContaController.changePassword] Erro inesperado:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro interno. Tente novamente mais tarde.",
+      });
+    }
+  };
+}

--- a/Project/src/middlewares/validateMinhaConta.ts
+++ b/Project/src/middlewares/validateMinhaConta.ts
@@ -1,0 +1,115 @@
+// src/middlewares/validateMinhaConta.ts
+// ─────────────────────────────────────────────────────────────────
+// Schemas Zod e middlewares de validação para o módulo "Minha Conta".
+// Responsabilidades:
+//   1. Validar e tipar o payload de edição de perfil (PATCH /users/me/profile)
+//   2. Validar e tipar o payload de alteração de senha (PATCH /users/me/password)
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response, NextFunction } from "express";
+import { z, ZodError } from "zod";
+
+// ══════════════════════════════════════════════════════════════════
+// SCHEMA 1 — Edição de Dados Pessoais (PATCH /users/me/profile)
+// ══════════════════════════════════════════════════════════════════
+
+const updateProfileSchema = z
+  .object({
+    nome: z
+      .string({ required_error: "O campo 'nome' é obrigatório." })
+      .trim()
+      .refine(
+        (val) => {
+          const parts = val.split(/\s+/).filter(Boolean);
+          return parts.length >= 2 && parts.every((p) => p.length >= 2);
+        },
+        { message: "Informe nome e sobrenome (mínimo 2 letras cada)." }
+      )
+      .optional(),
+
+    email: z
+      .string({ required_error: "O campo 'email' é obrigatório." })
+      .email({ message: "Formato de e-mail inválido." })
+      .toLowerCase()
+      .optional(),
+
+    crea: z
+      .string()
+      .trim()
+      .min(1, { message: "O campo 'crea' não pode ser vazio." })
+      .optional(),
+  })
+  .refine(
+    (data) => Object.keys(data).length > 0,
+    { message: "Informe ao menos um campo para atualizar." }
+  );
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+
+export function validateUpdateProfile(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const result = updateProfileSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = formatZodErrors(result.error);
+    res.status(400).json({
+      status: "error",
+      message: "Dados inválidos. Verifique os campos abaixo.",
+      errors,
+    });
+    return;
+  }
+
+  req.body = result.data;
+  next();
+}
+
+// ══════════════════════════════════════════════════════════════════
+// SCHEMA 2 — Alteração de Senha (PATCH /users/me/password)
+// ══════════════════════════════════════════════════════════════════
+
+const changePasswordSchema = z.object({
+  senhaAtual: z
+    .string({ required_error: "O campo 'senhaAtual' é obrigatório." })
+    .min(1, { message: "O campo 'senhaAtual' não pode ser vazio." }),
+
+  novaSenha: z
+    .string({ required_error: "O campo 'novaSenha' é obrigatório." })
+    .min(6, { message: "A nova senha deve ter no mínimo 6 caracteres." }),
+});
+
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+
+export function validateChangePassword(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const result = changePasswordSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = formatZodErrors(result.error);
+    res.status(400).json({
+      status: "error",
+      message: "Dados inválidos. Verifique os campos abaixo.",
+      errors,
+    });
+    return;
+  }
+
+  req.body = result.data;
+  next();
+}
+
+// ── Formatador de erros Zod → objeto { campo: mensagem } ─────────
+
+function formatZodErrors(error: ZodError): Record<string, string> {
+  return error.errors.reduce<Record<string, string>>((acc, issue) => {
+    const field = issue.path.join(".") || "general";
+    if (!acc[field]) acc[field] = issue.message;
+    return acc;
+  }, {});
+}

--- a/Project/src/routes/userRoutes.ts
+++ b/Project/src/routes/userRoutes.ts
@@ -1,7 +1,14 @@
 // src/routes/userRoutes.ts
 // ─────────────────────────────────────────────────────────────────
 // Mapeamento das rotas de usuário.
-// Pipeline: POST /users → validateUserRegistration → controller.register
+//
+// Rotas públicas:
+//   POST /users              → registro de novo usuário
+//
+// Rotas protegidas (Minha Conta — requerem authMiddleware):
+//   GET  /users/me           → leitura do perfil
+//   PATCH /users/me/profile  → edição de dados pessoais
+//   PATCH /users/me/password → alteração de senha
 // ─────────────────────────────────────────────────────────────────
 
 /**
@@ -93,13 +100,24 @@
 import { Router } from "express";
 import { UserController } from "../controllers/UserController";
 import { UserService } from "../services/UserService";
+import { MinhaContaController } from "../controllers/MinhaContaController";
+import { MinhaContaService } from "../services/MinhaContaService";
 import { validateUserRegistration } from "../middlewares/validateUserRegistration";
+import { validateUpdateProfile, validateChangePassword } from "../middlewares/validateMinhaConta";
+import { authMiddleware } from "../middlewares/authMiddleware";
 
 const router = Router();
 
 // Composição manual de dependências (sem IoC container)
 const userService = new UserService();
 const userController = new UserController(userService);
+
+const minhaContaService = new MinhaContaService();
+const minhaContaController = new MinhaContaController(minhaContaService);
+
+// ═══════════════════════════════════════════════════════════════════
+// ROTAS PÚBLICAS
+// ═══════════════════════════════════════════════════════════════════
 
 /**
  * @route  POST /users
@@ -110,6 +128,171 @@ router.post(
   "/",
   validateUserRegistration,
   userController.register
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// ROTAS PROTEGIDAS — Módulo "Minha Conta"
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * @swagger
+ * /users/me:
+ *   get:
+ *     summary: Retorna o perfil do usuário autenticado
+ *     description: Retorna os dados do usuário logado. O CPF é sempre mascarado no formato ***.XXX.XXX-** e o CREA só é retornado para perfil CONSTRUTOR.
+ *     tags:
+ *       - Minha Conta
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Perfil carregado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: string
+ *                           format: uuid
+ *                         nome:
+ *                           type: string
+ *                         email:
+ *                           type: string
+ *                         cpf:
+ *                           type: string
+ *                           example: "***.456.789-**"
+ *                         profile:
+ *                           type: string
+ *                           enum: [CONSTRUTOR, PROPRIETARIO]
+ *                         crea:
+ *                           type: string
+ *                           nullable: true
+ *       401:
+ *         description: Token não fornecido ou inválido
+ *       404:
+ *         description: Usuário não encontrado
+ *
+ * @route  GET /users/me
+ * @desc   Retorna o perfil do usuário autenticado (CPF mascarado, CREA condicional)
+ * @access Private
+ */
+router.get(
+  "/me",
+  authMiddleware,
+  minhaContaController.getMe
+);
+
+/**
+ * @swagger
+ * /users/me/profile:
+ *   patch:
+ *     summary: Atualiza os dados pessoais do usuário
+ *     description: Atualiza nome, e-mail e/ou CREA do usuário autenticado. Ao alterar o e-mail, verifica unicidade no banco. Retorna perfil atualizado com CPF mascarado.
+ *     tags:
+ *       - Minha Conta
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nome:
+ *                 type: string
+ *                 example: Carlos Almeida
+ *                 description: Nome completo (nome + sobrenome)
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: carlos@email.com
+ *                 description: Novo e-mail único no sistema
+ *               crea:
+ *                 type: string
+ *                 example: CREA-SP 987654/D
+ *                 description: Novo CREA (ignorado para perfil PROPRIETARIO)
+ *     responses:
+ *       200:
+ *         description: Perfil atualizado com sucesso
+ *       400:
+ *         description: Dados inválidos
+ *       401:
+ *         description: Token não fornecido ou inválido
+ *       404:
+ *         description: Usuário não encontrado
+ *       409:
+ *         description: E-mail já está em uso por outro usuário
+ *
+ * @route  PATCH /users/me/profile
+ * @desc   Atualiza nome, e-mail e/ou CREA do usuário autenticado
+ * @access Private
+ */
+router.patch(
+  "/me/profile",
+  authMiddleware,
+  validateUpdateProfile,
+  minhaContaController.updateProfile
+);
+
+/**
+ * @swagger
+ * /users/me/password:
+ *   patch:
+ *     summary: Altera a senha do usuário
+ *     description: Verifica a senha atual via bcrypt antes de salvar o hash da nova senha. A nova senha deve ter no mínimo 6 caracteres.
+ *     tags:
+ *       - Minha Conta
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - senhaAtual
+ *               - novaSenha
+ *             properties:
+ *               senhaAtual:
+ *                 type: string
+ *                 format: password
+ *                 example: SenhaAntiga@123
+ *               novaSenha:
+ *                 type: string
+ *                 format: password
+ *                 example: NovaSenha@456
+ *                 description: Mínimo 6 caracteres
+ *     responses:
+ *       200:
+ *         description: Senha alterada com sucesso
+ *       400:
+ *         description: Senha atual incorreta ou dados inválidos
+ *       401:
+ *         description: Token não fornecido ou inválido
+ *       404:
+ *         description: Usuário não encontrado
+ *
+ * @route  PATCH /users/me/password
+ * @desc   Altera senha após validar a senha atual com bcrypt
+ * @access Private
+ */
+router.patch(
+  "/me/password",
+  authMiddleware,
+  validateChangePassword,
+  minhaContaController.changePassword
 );
 
 export default router;

--- a/Project/src/services/MinhaContaService.ts
+++ b/Project/src/services/MinhaContaService.ts
@@ -1,0 +1,256 @@
+// src/services/MinhaContaService.ts
+// ─────────────────────────────────────────────────────────────────
+// Responsabilidades:
+//   1. Buscar e retornar perfil do usuário com CPF mascarado e
+//      regra de CREA por perfil (getMe)
+//   2. Atualizar dados pessoais com verificação de e-mail duplicado
+//      (updateProfile)
+//   3. Alterar senha com verificação da senha atual via bcrypt
+//      (changePassword)
+// ─────────────────────────────────────────────────────────────────
+
+import bcrypt from "bcrypt";
+import { ProfileType } from "@prisma/client";
+import { prisma } from "../lib/prisma";
+import { UpdateProfileInput, ChangePasswordInput } from "../middlewares/validateMinhaConta";
+
+// ── Constantes ────────────────────────────────────────────────────
+
+const BCRYPT_SALT_ROUNDS = 12;
+
+// ── Erros de domínio ──────────────────────────────────────────────
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictMinhaContaError extends Error {
+  public readonly field: string;
+  constructor(field: string, message: string) {
+    super(message);
+    this.name = "ConflictMinhaContaError";
+    this.field = field;
+  }
+}
+
+export class InvalidCredentialsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidCredentialsError";
+  }
+}
+
+// ── Tipo de retorno público do perfil ─────────────────────────────
+
+export interface UserProfileResponse {
+  id: string;
+  nome: string;
+  email: string;
+  cpf: string;       // Sempre mascarado: ***.456.789-**
+  profile: ProfileType;
+  crea: string | null; // null quando PROPRIETARIO
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+/**
+ * Mascara o CPF armazenado (somente dígitos) para o formato ***.456.789-**
+ * O CPF é salvo no banco apenas com dígitos (11 chars). Ex: "12345678901"
+ * Saída esperada: ***.456.789-**  (exibe posições 3-8 do número formatado)
+ *
+ * CPF formatado: XXX.YYY.ZZZ-WW
+ *   - Posições 0-2 (XXX): mascaradas → ***
+ *   - Posições 4-6 (YYY): exibidas
+ *   - Posições 8-10 (ZZZ): exibidas
+ *   - Posições 12-13 (WW): mascaradas → **
+ */
+function maskCpf(cpfDigits: string): string {
+  // Garante que temos exatamente 11 dígitos
+  const d = cpfDigits.replace(/\D/g, "").padStart(11, "0");
+  //                   ***  .  [d3d4d5]  .  [d6d7d8]  -  **
+  return `***.${d[3]}${d[4]}${d[5]}.${d[6]}${d[7]}${d[8]}-**`;
+}
+
+/**
+ * Formata a resposta de perfil aplicando as regras de negócio:
+ * - CPF sempre mascarado
+ * - CREA retornado apenas para CONSTRUTOR; null para PROPRIETARIO
+ */
+function formatProfile(
+  user: {
+    id: string;
+    nome: string;
+    email: string;
+    cpf: string;
+    profile: ProfileType;
+    construtor?: { crea: string } | null;
+  }
+): UserProfileResponse {
+  return {
+    id: user.id,
+    nome: user.nome,
+    email: user.email,
+    cpf: maskCpf(user.cpf),
+    profile: user.profile,
+    crea: user.profile === "CONSTRUTOR" ? (user.construtor?.crea ?? null) : null,
+  };
+}
+
+// ── Service ───────────────────────────────────────────────────────
+
+export class MinhaContaService {
+
+  // ================================================================
+  // GET /users/me — Leitura do Perfil
+  // ================================================================
+
+  /**
+   * Retorna os dados públicos do usuário autenticado.
+   * @throws {NotFoundError} se o userId não corresponder a nenhum usuário.
+   */
+  async getMe(userId: string): Promise<UserProfileResponse> {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        nome: true,
+        email: true,
+        cpf: true,
+        profile: true,
+        construtor: {
+          select: { crea: true },
+        },
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundError("Usuário não encontrado.");
+    }
+
+    return formatProfile(user);
+  }
+
+  // ================================================================
+  // PATCH /users/me/profile — Edição de Dados Pessoais
+  // ================================================================
+
+  /**
+   * Atualiza nome, e-mail e/ou crea do usuário.
+   * @throws {NotFoundError} se o usuário não for encontrado.
+   * @throws {ConflictMinhaContaError} se o novo e-mail já estiver em uso.
+   */
+  async updateProfile(
+    userId: string,
+    input: UpdateProfileInput
+  ): Promise<UserProfileResponse> {
+    // 1. Verificar se o usuário existe
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        profile: true,
+        construtor: { select: { crea: true } },
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundError("Usuário não encontrado.");
+    }
+
+    // 2. Se o e-mail está sendo alterado, verificar unicidade
+    if (input.email && input.email !== user.email) {
+      const emailInUse = await prisma.user.findUnique({
+        where: { email: input.email },
+        select: { id: true },
+      });
+
+      if (emailInUse) {
+        throw new ConflictMinhaContaError(
+          "email",
+          "Este e-mail já está em uso por outro usuário."
+        );
+      }
+    }
+
+    // 3. Atualizar tabela User (nome e/ou email)
+    const userUpdateData: { nome?: string; email?: string } = {};
+    if (input.nome) userUpdateData.nome = input.nome.trim();
+    if (input.email) userUpdateData.email = input.email;
+
+    if (Object.keys(userUpdateData).length > 0) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: userUpdateData,
+      });
+    }
+
+    // 4. Atualizar CREA (apenas para CONSTRUTOR e se o campo foi enviado)
+    if (input.crea !== undefined && user.profile === "CONSTRUTOR") {
+      await prisma.construtor.update({
+        where: { idUser: userId },
+        data: { crea: input.crea.trim() },
+      });
+    }
+
+    // 5. Re-buscar os dados atualizados para retornar a resposta formatada
+    const updated = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: {
+        id: true,
+        nome: true,
+        email: true,
+        cpf: true,
+        profile: true,
+        construtor: { select: { crea: true } },
+      },
+    });
+
+    return formatProfile(updated);
+  }
+
+  // ================================================================
+  // PATCH /users/me/password — Alteração de Senha
+  // ================================================================
+
+  /**
+   * Altera a senha do usuário após validar a senha atual.
+   * @throws {NotFoundError} se o usuário não for encontrado.
+   * @throws {InvalidCredentialsError} se a senha atual não conferir.
+   */
+  async changePassword(
+    userId: string,
+    input: ChangePasswordInput
+  ): Promise<void> {
+    // 1. Buscar o hash atual da senha
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, hashSenha: true },
+    });
+
+    if (!user) {
+      throw new NotFoundError("Usuário não encontrado.");
+    }
+
+    // 2. Comparar senha atual com o hash armazenado
+    const senhaCorreta = await bcrypt.compare(input.senhaAtual, user.hashSenha);
+
+    if (!senhaCorreta) {
+      throw new InvalidCredentialsError(
+        "A senha atual informada está incorreta."
+      );
+    }
+
+    // 3. Gerar hash da nova senha
+    const novoHash = await bcrypt.hash(input.novaSenha, BCRYPT_SALT_ROUNDS);
+
+    // 4. Persistir nova senha
+    await prisma.user.update({
+      where: { id: userId },
+      data: { hashSenha: novoHash },
+    });
+  }
+}


### PR DESCRIPTION


Esta PR atende às **US 5.1.2 e US 5.1.3** (Sprint 5), implementando os endpoints necessários para que os usuários (Construtores e Proprietários) possam consultar e editar seus dados cadastrais, além de alterar suas senhas com segurança.

---

## 🛠️ Modificações e Endpoints Implementados

Foi adotada a arquitetura padrão do projeto (Controller > Service > Zod Validator) com a criação de 3 novas rotas protegidas no `userRoutes.ts`:

### 1. `GET /users/me` (Consulta de Perfil)

* **Máscara de Segurança:** Implementada a função `maskCpf` no Service. O CPF agora é mascarado diretamente no servidor (ex: `***.444.777-`), impedindo vazamento do dado sensível no tráfego de rede.
* **Filtro de Role:** O campo `crea` é retornado dinamicamente. Se o token pertencer a um `CONSTRUTOR`, o CREA é exibido; se for um `PROPRIETARIO`, o campo é ignorado silenciosamente na resposta.

### 2. `PATCH /users/me/profile` (Edição de Dados Pessoais)

* Suporte a atualizações parciais (mutabilidade flexível) de `nome`, `email` e `crea`.
* **Proteção de Conflito:** Adicionada verificação no banco (`assertUniqueness`). Se o usuário tentar atualizar para um e-mail já existente em outra conta, a API recusa com `409 Conflict`.
* Retorna o payload atualizado passando novamente pelos filtros de segurança (Máscara de CPF e exclusão de CREA).

### 3. `PATCH /users/me/password` (Alteração de Senha)

* **Validação de Autoria:** Exige a `senhaAtual` no body. O Service utiliza `bcrypt.compare` contra o hash do banco e devolve `400 InvalidCredentialsError` caso não bata.
* **Criptografia:** A `novaSenha` é validada pelo Zod (mínimo de 6 caracteres) e sofre hash com `bcrypt` antes de persistir no banco.

---

## 📁 Arquivos Criados/Alterados

* `src/middlewares/validateMinhaConta.ts` (Schemas Zod)
* `src/services/MinhaContaService.ts` (Regras de negócio e sanitização de dados)
* `src/controllers/MinhaContaController.ts` (Handlers HTTP)
* `src/routes/userRoutes.ts` (Inclusão das rotas de profile e password)

---

## 🧪 Como o revisor pode testar?

1. Faça login via `POST /auth/login` e capture o Bearer Token.
2. Faça um `GET /users/me` e verifique a aplicação da máscara no CPF.
3. Faça um `PATCH /users/me/profile` passando apenas `{"nome": "Novo Nome"}` para testar o update parcial.
4. Faça um `PATCH /users/me/password` simulando a troca de senha (teste passar a senha atual errada para forçar o bloqueio de segurança).