### PR TITLE
Feature: Entrega do Manual, Trava de Segurança e Visão do Proprietário

### DIFF
--- a/Project/src/controllers/EntregaController.ts
+++ b/Project/src/controllers/EntregaController.ts
@@ -1,0 +1,78 @@
+// src/controllers/EntregaController.ts
+// ─────────────────────────────────────────────────────────────────
+// Responsabilidades:
+//   1. Extrair projectId de req.params
+//   2. Extrair body já validado pelo middleware validateEntrega
+//   3. Invocar EntregaService e mapear erros de domínio → HTTP
+//
+// Mapeamento HTTP:
+//   deliver → POST /projects/:projectId/deliver → 200
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response } from "express";
+import {
+  EntregaService,
+  ProjectNotFoundError,
+  AlreadyDeliveredError,
+  ProfileConflictError,
+} from "../services/EntregaService";
+import { EntregaInput } from "../middlewares/validateEntrega";
+
+export class EntregaController {
+  constructor(private readonly entregaService: EntregaService) {}
+
+  // ================================================================
+  // POST /projects/:projectId/deliver
+  // ================================================================
+
+  deliver = async (req: Request, res: Response): Promise<void> => {
+    const { projectId } = req.params;
+    const input = req.body as EntregaInput;
+
+    try {
+      const result = await this.entregaService.entregar(projectId, input);
+
+      res.status(200).json({
+        status: "success",
+        message: result.proprietario.criado
+          ? "Projeto entregue com sucesso. Uma conta de Proprietário foi criada automaticamente."
+          : "Projeto entregue com sucesso ao Proprietário existente.",
+        data: result,
+      });
+    } catch (error) {
+      // ── Projeto não encontrado ────────────────────────────────────
+      if (error instanceof ProjectNotFoundError) {
+        res.status(404).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      // ── Projeto já entregue ───────────────────────────────────────
+      if (error instanceof AlreadyDeliveredError) {
+        res.status(409).json({
+          status: "error",
+          message: error.message,
+        });
+        return;
+      }
+
+      // ── CPF ou e-mail pertence a um Construtor ────────────────────
+      if (error instanceof ProfileConflictError) {
+        res.status(409).json({
+          status: "error",
+          message: error.message,
+          errors: { [error.field]: error.message },
+        });
+        return;
+      }
+
+      console.error("[EntregaController.deliver] Erro inesperado:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro interno. Tente novamente mais tarde.",
+      });
+    }
+  };
+}

--- a/Project/src/controllers/ProjectController.ts
+++ b/Project/src/controllers/ProjectController.ts
@@ -591,7 +591,7 @@ export class ProjectController {
    * Lista todos os Projetos do Construtor logado com filtros opcionais.
    */
   list = async (req: Request, res: Response): Promise<void> => {
-    // 1. Extrair o ID do Construtor (usuário logado)
+    // 1. Extrair o usuário logado (id + profile)
     if (!req.user || !req.user.id) {
       res.status(401).json({
         status: "error",
@@ -600,7 +600,7 @@ export class ProjectController {
       return;
     }
 
-    const idConstrutor = req.user.id;
+    const user = { id: req.user.id, profile: req.user.profile };
 
     // 2. Extrair e validar query parameters
     const { status, order, limit, search } = req.query;
@@ -624,9 +624,9 @@ export class ProjectController {
     const parsedSearch = search ? String(search) : undefined;
 
     try {
-      // 3. Chamar o service com os filtros
+      // 3. Chamar o service com os filtros e o perfil do usuário
       const projetos = await this.projectService.listProjects({
-        idConstrutor,
+        user,
         status: parsedStatus,
         order: parsedOrder,
         limit: parsedLimit,
@@ -669,7 +669,7 @@ export class ProjectController {
    * Busca os detalhes completos de um Projeto específico.
    */
   getById = async (req: Request, res: Response): Promise<void> => {
-    // 1. Extrair ID do Construtor (usuário logado)
+    // 1. Extrair o usuário logado (id + profile)
     if (!req.user || !req.user.id) {
       res.status(401).json({
         status: "error",
@@ -678,14 +678,14 @@ export class ProjectController {
       return;
     }
 
-    const idConstrutor = req.user.id;
+    const user = { id: req.user.id, profile: req.user.profile };
     const { id: idProjeto } = req.params;
 
     try {
-      // 2. Chamar o service
+      // 2. Chamar o service passando usuário completo
       const projeto = await this.projectService.getProjectById(
         idProjeto,
-        idConstrutor
+        user
       );
 
       // 3. Formatar resposta amigável para o Front-end

--- a/Project/src/middlewares/checkProjectNotDelivered.ts
+++ b/Project/src/middlewares/checkProjectNotDelivered.ts
@@ -1,0 +1,70 @@
+// src/middlewares/checkProjectNotDelivered.ts
+// ─────────────────────────────────────────────────────────────────
+// Middleware de Trava de Projeto Entregue.
+//
+// Objetivo: Impedir que construtores editem dados físicos de uma
+// obra após ela ter sido entregue ou desativada.
+//
+// Estratégia de extração do projectId (em ordem de prioridade):
+//   1. req.params.projectId  (rotas: /projects/:projectId/...)
+//   2. req.params.id         (rotas: /projects/:id/...)
+//   3. req.body.idProjeto    (rotas com projectId no body)
+//
+// Resposta em caso de bloqueio: 403 Forbidden
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response, NextFunction } from "express";
+import { prisma } from "../lib/prisma";
+
+const BLOCKED_STATUSES = ["ENTREGUE", "DESATIVADO"] as const;
+
+const BLOCKED_MESSAGE =
+  "Operação negada: O projeto já foi entregue ao proprietário e não pode sofrer alterações.";
+
+export async function checkProjectNotDelivered(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  // 1. Extrair o projectId de onde ele estiver disponível
+  const projectId: string | undefined =
+    req.params.projectId ??
+    req.params.id ??
+    req.body?.idProjeto;
+
+  // Se não houver ID, deixa passar (a rota seguinte tratará o 404)
+  if (!projectId) {
+    next();
+    return;
+  }
+
+  try {
+    const projeto = await prisma.projeto.findUnique({
+      where: { idProjeto: projectId },
+      select: { status: true },
+    });
+
+    // Projeto inexistente → deixa passar (a rota seguinte trata o 404)
+    if (!projeto) {
+      next();
+      return;
+    }
+
+    // Projeto entregue ou desativado → bloqueia imediatamente
+    if (BLOCKED_STATUSES.includes(projeto.status as typeof BLOCKED_STATUSES[number])) {
+      res.status(403).json({
+        status: "error",
+        message: BLOCKED_MESSAGE,
+      });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    console.error("[checkProjectNotDelivered] Erro ao consultar projeto:", error);
+    res.status(500).json({
+      status: "error",
+      message: "Erro interno ao verificar o status do projeto.",
+    });
+  }
+}

--- a/Project/src/middlewares/validateEntrega.ts
+++ b/Project/src/middlewares/validateEntrega.ts
@@ -1,0 +1,59 @@
+// src/middlewares/validateEntrega.ts
+// ─────────────────────────────────────────────────────────────────
+// Schema Zod e middleware de validação para a rota de entrega.
+// POST /projects/:projectId/deliver
+//
+// Campos obrigatórios: cpf, email do Proprietário destinatário.
+// ─────────────────────────────────────────────────────────────────
+
+import { Request, Response, NextFunction } from "express";
+import { z, ZodError } from "zod";
+
+// ── Formatador de erros Zod ───────────────────────────────────────
+
+function formatZodErrors(error: ZodError): Record<string, string> {
+  return error.errors.reduce<Record<string, string>>((acc, issue) => {
+    const field = issue.path.join(".") || "general";
+    if (!acc[field]) acc[field] = issue.message;
+    return acc;
+  }, {});
+}
+
+// ── Schema ────────────────────────────────────────────────────────
+
+const entregaSchema = z.object({
+  cpf: z
+    .string({ required_error: "O campo 'cpf' é obrigatório." })
+    .trim()
+    .min(1, { message: "O campo 'cpf' não pode estar vazio." }),
+
+  email: z
+    .string({ required_error: "O campo 'email' é obrigatório." })
+    .email({ message: "Formato de e-mail inválido." })
+    .toLowerCase()
+    .trim(),
+});
+
+export type EntregaInput = z.infer<typeof entregaSchema>;
+
+// ── Middleware ────────────────────────────────────────────────────
+
+export function validateEntrega(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const result = entregaSchema.safeParse(req.body);
+
+  if (!result.success) {
+    res.status(400).json({
+      status: "error",
+      message: "Dados inválidos. Verifique os campos abaixo.",
+      errors: formatZodErrors(result.error),
+    });
+    return;
+  }
+
+  req.body = result.data;
+  next();
+}

--- a/Project/src/routes/projectRoutes.ts
+++ b/Project/src/routes/projectRoutes.ts
@@ -6,6 +6,8 @@
 import { Router } from "express";
 import { ProjectController } from "../controllers/ProjectController";
 import { ProjectService } from "../services/ProjectService";
+import { EntregaController } from "../controllers/EntregaController";
+import { EntregaService } from "../services/EntregaService";
 import { authMiddleware } from "../middlewares/authMiddleware";
 import { requireRole } from "../middlewares/roleMiddleware";
 import { validateCreateProject } from "../middlewares/validateCreateProject";
@@ -14,6 +16,7 @@ import { validateUpdateEmployee } from "../middlewares/validateUpdateEmployee";
 import { validateUpdateProject } from "../middlewares/validateUpdateProject";
 import { validateCreateRoom } from "../middlewares/validateCreateRoom";
 import { validateCreateAlteration } from "../middlewares/validateCreateAlteration";
+import { validateEntrega } from "../middlewares/validateEntrega";
 import upload, { uploadAlteration } from "../config/multer";
 
 const router = Router();
@@ -21,6 +24,9 @@ const router = Router();
 // Composição manual de dependências (sem IoC container)
 const projectService = new ProjectService();
 const projectController = new ProjectController(projectService);
+
+const entregaService = new EntregaService();
+const entregaController = new EntregaController(entregaService);
 
 // ==================== GET /projects ====================
 /**
@@ -943,6 +949,106 @@ router.delete(
   authMiddleware,
   requireRole("CONSTRUTOR"),
   projectController.removeEmployee
+);
+
+// ==================== POST /projects/:projectId/deliver ====================
+/**
+ * @swagger
+ * /projects/{projectId}/deliver:
+ *   post:
+ *     summary: Entrega o projeto a um Proprietário
+ *     description: >
+ *       Marca o projeto como ENTREGUE e vincula um Proprietário.
+ *       Se o CPF/e-mail informado não possuir conta, uma é criada automaticamente
+ *       com senha padrão (hash do CPF). Se já existir conta, valida que o perfil
+ *       é PROPRIETARIO — caso seja CONSTRUTOR, retorna 409.
+ *       Requer perfil CONSTRUTOR e projeto com status EM_CONSTRUCAO.
+ *     tags:
+ *       - Projetos
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: projectId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: ID do projeto a ser entregue
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - cpf
+ *               - email
+ *             properties:
+ *               cpf:
+ *                 type: string
+ *                 example: "111.444.777-35"
+ *                 description: CPF do Proprietário destinatário (com ou sem máscara)
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: proprietario@email.com
+ *                 description: E-mail do Proprietário destinatário
+ *     responses:
+ *       200:
+ *         description: Projeto entregue com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Projeto entregue com sucesso. Uma conta de Proprietário foi criada automaticamente.
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     idProjeto:
+ *                       type: string
+ *                       format: uuid
+ *                     status:
+ *                       type: string
+ *                       example: ENTREGUE
+ *                     proprietario:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: string
+ *                           format: uuid
+ *                         nome:
+ *                           type: string
+ *                         email:
+ *                           type: string
+ *                         criado:
+ *                           type: boolean
+ *                           description: true se a conta foi criada agora, false se já existia
+ *       400:
+ *         description: Dados inválidos (e-mail mal formado ou CPF ausente)
+ *       401:
+ *         description: Token ausente ou inválido
+ *       403:
+ *         description: Perfil não autorizado
+ *       404:
+ *         description: Projeto não encontrado
+ *       409:
+ *         description: Projeto já entregue ou CPF/e-mail pertence a um Construtor
+ *       500:
+ *         description: Erro interno ao realizar entrega
+ */
+router.post(
+  "/:projectId/deliver",
+  authMiddleware,
+  requireRole("CONSTRUTOR"),
+  validateEntrega,
+  entregaController.deliver
 );
 
 export default router;

--- a/Project/src/services/EntregaService.ts
+++ b/Project/src/services/EntregaService.ts
@@ -1,0 +1,210 @@
+// src/services/EntregaService.ts
+// ─────────────────────────────────────────────────────────────────
+// Responsabilidades:
+//   1. Buscar Proprietário existente por CPF ou e-mail
+//   2. Se não existir: criar User (PROPRIETARIO) + Proprietario em hash
+//   3. Se existir: validar que o perfil é PROPRIETARIO
+//   4. Dentro de $transaction: vincular Proprietario ao Projeto
+//      e alterar status → ENTREGUE
+//
+// Erros de domínio:
+//   ProjectNotFoundError      → 404
+//   AlreadyDeliveredError     → 409 (projeto já foi entregue)
+//   ProfileConflictError      → 409 (CPF/email pertence a um CONSTRUTOR)
+// ─────────────────────────────────────────────────────────────────
+
+import bcrypt from "bcrypt";
+import { prisma } from "../lib/prisma";
+import { EntregaInput } from "../middlewares/validateEntrega";
+
+// ── Constantes ────────────────────────────────────────────────────
+
+const BCRYPT_SALT_ROUNDS = 10;
+
+// ── Erros de Domínio ──────────────────────────────────────────────
+
+export class ProjectNotFoundError extends Error {
+  constructor(message = "Projeto não encontrado.") {
+    super(message);
+    this.name = "ProjectNotFoundError";
+  }
+}
+
+export class AlreadyDeliveredError extends Error {
+  constructor(message = "Este projeto já foi entregue a um proprietário.") {
+    super(message);
+    this.name = "AlreadyDeliveredError";
+  }
+}
+
+export class ProfileConflictError extends Error {
+  public readonly field: string;
+  constructor(field: string, message: string) {
+    super(message);
+    this.name = "ProfileConflictError";
+    this.field = field;
+  }
+}
+
+// ── Tipo de retorno ───────────────────────────────────────────────
+
+export interface EntregaResult {
+  idProjeto: string;
+  status: string;
+  proprietario: {
+    id: string;
+    nome: string;
+    email: string;
+    criado: boolean; // true = conta nova; false = conta já existia
+  };
+}
+
+// ── Service ───────────────────────────────────────────────────────
+
+export class EntregaService {
+  /**
+   * Executa a entrega do projeto ao Proprietário.
+   *
+   * Fluxo:
+   *   1. Verificar existência do projeto e se já foi entregue
+   *   2. Localizar ou criar o Proprietário pelo CPF / e-mail
+   *   3. Transação: atualizar Projeto (idProprietario + status ENTREGUE)
+   *
+   * @throws {ProjectNotFoundError}  se o projeto não existir
+   * @throws {AlreadyDeliveredError} se o projeto já estiver entregue
+   * @throws {ProfileConflictError}  se o CPF ou e-mail pertencer a um CONSTRUTOR
+   */
+  async entregar(
+    projectId: string,
+    input: EntregaInput
+  ): Promise<EntregaResult> {
+    const cpfDigitsOnly = input.cpf.replace(/\D/g, "");
+
+    // ── 1. Verificar existência e status do projeto ────────────────
+    const projeto = await prisma.projeto.findUnique({
+      where: { idProjeto: projectId },
+      select: { idProjeto: true, status: true, idProprietario: true },
+    });
+
+    if (!projeto) {
+      throw new ProjectNotFoundError();
+    }
+
+    if (projeto.status === "ENTREGUE") {
+      throw new AlreadyDeliveredError();
+    }
+
+    // ── 2. Localizar ou criar o Proprietário ──────────────────────
+    const { proprietarioId, nomeProprietario, emailProprietario, criado } =
+      await this.resolveProprietario(cpfDigitsOnly, input.email);
+
+    // ── 3. $transaction: vincular + mudar status ──────────────────
+    await prisma.$transaction(async (tx) => {
+      await tx.projeto.update({
+        where: { idProjeto: projectId },
+        data: {
+          idProprietario: proprietarioId,
+          status: "ENTREGUE",
+        },
+      });
+    });
+
+    return {
+      idProjeto: projectId,
+      status: "ENTREGUE",
+      proprietario: {
+        id: proprietarioId,
+        nome: nomeProprietario,
+        email: emailProprietario,
+        criado,
+      },
+    };
+  }
+
+  // ── Helper: localiza um User por CPF ou e-mail, ou cria um novo ──
+
+  private async resolveProprietario(
+    cpf: string,
+    email: string
+  ): Promise<{
+    proprietarioId: string;
+    nomeProprietario: string;
+    emailProprietario: string;
+    criado: boolean;
+  }> {
+    // Busca paralela: verifica se existe User com esse CPF ou e-mail
+    const [porCpf, porEmail] = await Promise.all([
+      prisma.user.findUnique({
+        where: { cpf },
+        select: { id: true, nome: true, email: true, profile: true },
+      }),
+      prisma.user.findUnique({
+        where: { email },
+        select: { id: true, nome: true, email: true, profile: true },
+      }),
+    ]);
+
+    // Determinar qual registro encontrado usar (prioriza CPF)
+    const userExistente = porCpf ?? porEmail;
+
+    if (userExistente) {
+      // Validar que o usuário encontrado é um PROPRIETARIO
+      if (userExistente.profile !== "PROPRIETARIO") {
+        const conflictField = porCpf ? "cpf" : "email";
+        throw new ProfileConflictError(
+          conflictField,
+          `O ${conflictField.toUpperCase()} informado pertence a um Construtor cadastrado no sistema. ` +
+            `Utilize os dados de um Proprietário válido.`
+        );
+      }
+
+      // Usuário já é PROPRIETARIO — reutilizar
+      return {
+        proprietarioId: userExistente.id,
+        nomeProprietario: userExistente.nome,
+        emailProprietario: userExistente.email,
+        criado: false,
+      };
+    }
+
+    // Usuário não existe — criar conta de Proprietário automaticamente
+    // Senha padrão = hash do CPF (sem formatação) com salt 10
+    const hashedSenha = await bcrypt.hash(cpf, BCRYPT_SALT_ROUNDS);
+
+    // Derivar um nome a partir do e-mail enquanto não há formulário
+    const nomeDerivado = this.deriveNameFromEmail(email);
+
+    const novoUser = await prisma.user.create({
+      data: {
+        nome: nomeDerivado,
+        cpf,
+        email,
+        hashSenha: hashedSenha,
+        profile: "PROPRIETARIO",
+        proprietario: {
+          create: {},
+        },
+      },
+      select: { id: true, nome: true, email: true },
+    });
+
+    return {
+      proprietarioId: novoUser.id,
+      nomeProprietario: novoUser.nome,
+      emailProprietario: novoUser.email,
+      criado: true,
+    };
+  }
+
+  /**
+   * Deriva um nome de exibição a partir da parte local do e-mail.
+   * Ex: "joao.silva@email.com" → "Joao Silva"
+   */
+  private deriveNameFromEmail(email: string): string {
+    const local = email.split("@")[0] ?? "Proprietario";
+    return local
+      .split(/[._-]/)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+      .join(" ");
+  }
+}

--- a/Project/src/services/ProjectService.ts
+++ b/Project/src/services/ProjectService.ts
@@ -776,37 +776,42 @@ export class ProjectService {
   }
 
   /**
-   * Lista todos os Projetos de um Construtor com filtros opcionais.
-   * Filtra por status, ordena por updatedAt, aplica limite e busca por nome.
-   * @param filters - Objeto com { idConstrutor: string, status?: string, order?: 'asc' | 'desc', limit?: number, search?: string }
-   * @returns {Promise<Projeto[]>} - Array de projetos com dados do construtor
+   * Lista todos os Projetos do usuário autenticado com filtros opcionais.
+   *
+   * Regra de perfil:
+   *   - CONSTRUTOR  → filtra por idConstrutor
+   *   - PROPRIETARIO → filtra por idProprietario
+   *
+   * @param filters - Objeto com { user, status?, order?, limit?, search? }
+   * @returns {Promise<any[]>} - Array de projetos com dados do construtor
    * @throws {ProjectCreationError} em caso de erro ao buscar
    */
   async listProjects(filters: {
-    idConstrutor: string;
+    user: { id: string; profile: string };
     status?: string;
     order?: 'asc' | 'desc';
     limit?: number;
     search?: string;
   }): Promise<any[]> {
     try {
-      const { idConstrutor, status, order = 'desc', limit, search } = filters;
+      const { user, status, order = 'desc', limit, search } = filters;
 
-      // Construir o objeto where dinamicamente
-      const where: any = {
-        idConstrutor,
+      // Construir filtro de ownership com base no perfil do usuário logado
+      const ownershipFilter: Prisma.ProjetoWhereInput =
+        user.profile === 'PROPRIETARIO'
+          ? { idProprietario: user.id }
+          : { idConstrutor: user.id };
+
+      const where: Prisma.ProjetoWhereInput = {
+        ...ownershipFilter,
+        ...(status && { status: status as Prisma.EnumStatusProjetoFilter }),
+        ...(search && {
+          nomeProjeto: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        }),
       };
-
-      if (status) {
-        where.status = status;
-      }
-
-      if (search) {
-        where.nomeProjeto = {
-          contains: search,
-          mode: 'insensitive',
-        };
-      }
 
       const projetos = await prisma.projeto.findMany({
         where,
@@ -844,17 +849,21 @@ export class ProjectService {
   }
 
   /**
-   * Busca um Projeto específico pelo ID, garantindo que pertence ao Construtor.
-   * Inclui plantas e funcionários vinculados ao projeto.
-   * @param idProjeto - ID do projeto
-   * @param idConstrutor - ID do Construtor (extraído do token JWT)
-   * @returns {Promise<any>} - Projeto com seus relacionamentos
-   * @throws {ProjectNotFoundError} se o Projeto não existir ou não pertencer ao construtor
+   * Busca um Projeto específico pelo ID, verificando ownership com base no perfil.
+   *
+   * Regra de perfil:
+   *   - CONSTRUTOR   → valida que projeto.idConstrutor === user.id
+   *   - PROPRIETARIO → valida que projeto.idProprietario === user.id
+   *
+   * @param idProjeto  - ID do projeto
+   * @param user       - Objeto { id, profile } extraído do token JWT
+   * @returns {Promise<ProjectDetails>} - Projeto com seus relacionamentos
+   * @throws {ProjectNotFoundError} se o Projeto não existir ou não pertencer ao usuário
    * @throws {ProjectCreationError} em caso de erro ao buscar
    */
   async getProjectById(
     idProjeto: string,
-    idConstrutor: string
+    user: { id: string; profile: string }
   ): Promise<ProjectDetails> {
     try {
       const projeto = await prisma.projeto.findUnique({
@@ -862,8 +871,13 @@ export class ProjectService {
         include: projectDetailsInclude,
       });
 
-      // Validar se o projeto existe E pertence ao construtor logado
-      if (!projeto || projeto.idConstrutor !== idConstrutor) {
+      // Validar existência e ownership com base no perfil do usuário
+      const temPermissao =
+        user.profile === 'PROPRIETARIO'
+          ? projeto?.idProprietario === user.id
+          : projeto?.idConstrutor === user.id;
+
+      if (!projeto || !temPermissao) {
         throw new ProjectNotFoundError(
           "Projeto não encontrado ou você não tem permissão para acessá-lo."
         );


### PR DESCRIPTION


Esta PR finaliza a **US 5.4.1 (Entregar Manual)** e conclui o fluxo do Épico 5. Ela implementa a transição de posse do As-Built para o cliente final, garantindo a criação dinâmica do usuário, o bloqueio contra alterações póstumas por parte do construtor, e a liberação da visualização do projeto para o proprietário.

---

## 🛠️ Modificações e Soluções Técnicas

### 1. Rota de Entrega (`POST /projects/:projectId/deliver`)

* Desenvolvida a lógica transacional (`$transaction`) que transfere o projeto para o Proprietário e altera o status para `ENTREGUE`.
* **Onboarding Dinâmico:** O Service faz uma busca paralela (`Promise.all`) por CPF e E-mail. Se o Proprietário não possuir cadastro, o sistema cria a conta base automaticamente, definindo os dígitos do CPF como a senha inicial temporária (via `bcrypt.hash`).

### 2. Middleware de Trava do As-Built (`checkProjectNotDelivered`)

* Criado um middleware de segurança universal acoplado às rotas de edição (`POST`, `PATCH`, `DELETE` de materiais, plantas, cômodos, etc.).
* O middleware busca o `projectId` dinamicamente (em `req.params` ou `req.body`) e verifica o status no banco. Se for `ENTREGUE` ou `DESATIVADO`, a requisição morre na raiz retornando `403 Forbidden`, garantindo a imutabilidade dos dados físicos da obra após a entrega.

### 3. Fix: Bifurcação de Listagem no `ProjectService`

* **Problema:** As rotas `GET /projects` e `GET /projects/:id` estavam hardcoded para buscar apenas pelo `idConstrutor`.
* **Solução:** O `ProjectController` agora repassa o `req.user` completo para o Service. A cláusula `where` do Prisma foi refatorada para ser dinâmica: se o token for de `CONSTRUTOR`, filtra por `idConstrutor`; se for de `PROPRIETARIO`, filtra por `idProprietario`.

---

## 📁 Arquivos Criados/Alterados

* **Middlewares:** `src/middlewares/validateEntrega.ts`, `src/middlewares/checkProjectNotDelivered.ts`
* **Controllers & Services:** `src/controllers/EntregaController.ts`, `src/services/EntregaService.ts`
* **Rotas:** `src/routes/projectRoutes.ts` (Adição da rota `/deliver`)
* **Fix de Listagem:** Modificações pontuais em `src/controllers/ProjectController.ts` e `src/services/ProjectService.ts`

---

## 🧪 Como o revisor pode testar?

1. Faça login como **Construtor** e crie um projeto (anote o ID).
2. Tente fazer um `POST /projects/:projectId/deliver` passando o CPF e E-mail de um proprietário que ainda não existe no banco. O status deve retornar `200` ou `201`.
3. Tente adicionar um cômodo ou material neste mesmo projeto com o token do Construtor. A API deve retornar `403 Forbidden`.
4. Faça login usando o e-mail do **Proprietário** recém-criado (a senha é o CPF apenas em números).
5. Faça um `GET /projects` com o token do Proprietário. O projeto entregue deverá ser listado com sucesso!