### PR TITLE
feat(alterations): implementa GET /projects/:id/alterations?idComodo=X

### DIFF
--- a/Project/src/controllers/ProjectController.ts
+++ b/Project/src/controllers/ProjectController.ts
@@ -21,6 +21,8 @@ import {
   RoomCreationError,
   ProjectRooms,
   AlterationCreationError,
+  AlterationNotFoundError,
+  AlterationListItem,
   RoomNotFoundError,
 } from "../services/ProjectService";
 import { CreateProjectInput } from "../middlewares/validateCreateProject";
@@ -770,6 +772,92 @@ export class ProjectController {
       res.status(500).json({
         status: "error",
         message: "Ocorreu um erro ao buscar os andares e cômodos. Tente novamente mais tarde.",
+      });
+    }
+  };
+
+  /**
+   * GET /projects/:id/alterations?idComodo=<number>
+   * Lista as alterações de um cômodo específico.
+   * Acessível por CONSTRUTOR (dono) e PROPRIETARIO (vinculado).
+   */
+  listAlterationsByRoom = async (req: Request, res: Response): Promise<void> => {
+    if (!req.user || !req.user.id) {
+      res.status(401).json({
+        status: "error",
+        message: "Usuário não autenticado. Realize o login primeiro.",
+      });
+      return;
+    }
+
+    const user = { id: req.user.id, profile: req.user.profile };
+    const { id: idProjeto } = req.params;
+
+    // Valida e converte o query param idComodo
+    const rawIdComodo = req.query.idComodo;
+    if (!rawIdComodo || isNaN(Number(rawIdComodo)) || !Number.isInteger(Number(rawIdComodo)) || Number(rawIdComodo) <= 0) {
+      res.status(400).json({
+        status: "error",
+        message: "O parâmetro 'idComodo' é obrigatório e deve ser um número inteiro positivo.",
+      });
+      return;
+    }
+
+    const idComodo = Number(rawIdComodo);
+
+    try {
+      const alteracoes = await this.projectService.listAlterationsByRoom(
+        idProjeto,
+        idComodo,
+        user
+      );
+
+      res.status(200).json({
+        status: "success",
+        message: "Alterações do cômodo listadas com sucesso.",
+        data: {
+          alteracoes: alteracoes.map((alt) => ({
+            idAlteracao:        alt.idAlteracao,
+            nomeAlteracao:      alt.nomeAlteracao,
+            descricaoAlteracao: alt.descricaoAlteracao,
+            area:               alt.area,
+            dataAlteracao:      alt.dataAlteracao,
+            idComodo:           alt.idComodo,
+            idAndar:            alt.idAndar,
+            fotos:              alt.fotos.map((f) => ({
+              idFoto:    f.idFoto,
+              urlDaFoto: f.urlDaFoto,
+            })),
+            funcionarios: alt.funcionarios.map((vinculo) => ({
+              funcionario: {
+                idFunc:   vinculo.funcionario.idFunc,
+                nomeFunc: vinculo.funcionario.nomeFunc,
+                cargo:    vinculo.funcionario.cargo,
+              },
+            })),
+          })),
+        },
+      });
+    } catch (error) {
+      if (error instanceof ProjectNotFoundError) {
+        res.status(404).json({ status: "error", message: error.message });
+        return;
+      }
+
+      if (error instanceof RoomNotFoundError) {
+        res.status(404).json({ status: "error", message: error.message });
+        return;
+      }
+
+      if (error instanceof AlterationCreationError) {
+        res.status(400).json({ status: "error", message: error.message });
+        return;
+      }
+
+      console.error("[ProjectController] Erro ao listar alterações do cômodo:", error);
+      res.status(500).json({
+        status: "error",
+        message: "Ocorreu um erro ao listar as alterações. Tente novamente mais tarde.",
       });
     }
   };

--- a/Project/src/routes/projectRoutes.ts
+++ b/Project/src/routes/projectRoutes.ts
@@ -352,6 +352,114 @@ router.get(
   projectController.getRooms
 );
 
+// ==================== GET /projects/:id/alterations ====================
+/**
+ * @swagger
+ * /projects/{id}/alterations:
+ *   get:
+ *     summary: Lista as alterações de um cômodo específico do projeto
+ *     description: >
+ *       Retorna todas as alterações registradas para um cômodo dentro de um
+ *       projeto, ordenadas por data crescente. Acessível pelo Construtor (dono
+ *       do projeto) e pelo Proprietário (vinculado ao projeto após entrega).
+ *     tags:
+ *       - Alterações
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: ID do projeto
+ *       - name: idComodo
+ *         in: query
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: ID inteiro do cômodo cujas alterações serão listadas
+ *     responses:
+ *       200:
+ *         description: Alterações listadas com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Alterações do cômodo listadas com sucesso.
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     alteracoes:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           idAlteracao:
+ *                             type: string
+ *                             format: uuid
+ *                           nomeAlteracao:
+ *                             type: string
+ *                           descricaoAlteracao:
+ *                             type: string
+ *                           area:
+ *                             type: string
+ *                             enum: [ARQUITETONICA, ESTRUTURAL, HIDROSSANITARIA, ELETRICA]
+ *                           dataAlteracao:
+ *                             type: string
+ *                             format: date-time
+ *                           idComodo:
+ *                             type: integer
+ *                           idAndar:
+ *                             type: integer
+ *                           fotos:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 idFoto:
+ *                                   type: string
+ *                                   format: uuid
+ *                                 urlDaFoto:
+ *                                   type: string
+ *                           funcionarios:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 funcionario:
+ *                                   type: object
+ *                                   properties:
+ *                                     idFunc:
+ *                                       type: string
+ *                                       format: uuid
+ *                                     nomeFunc:
+ *                                       type: string
+ *                                     cargo:
+ *                                       type: string
+ *       400:
+ *         description: Parâmetro idComodo ausente ou inválido
+ *       401:
+ *         description: Usuário não autenticado
+ *       404:
+ *         description: Projeto ou cômodo não encontrado
+ *       500:
+ *         description: Erro interno ao listar alterações
+ */
+router.get(
+  "/:id/alterations",
+  authMiddleware,
+  projectController.listAlterationsByRoom
+);
+
 // ==================== POST /projects/:id/rooms ====================
 /**
  * @swagger

--- a/Project/src/services/ProjectService.ts
+++ b/Project/src/services/ProjectService.ts
@@ -138,6 +138,35 @@ export class AlterationCreationError extends Error {
   }
 }
 
+export class AlterationNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AlterationNotFoundError";
+  }
+}
+
+// Shape de retorno da listagem de alterações por cômodo
+export type AlterationListItem = {
+  idAlteracao: string;
+  nomeAlteracao: string;
+  descricaoAlteracao: string;
+  area: AreaAlteracao;
+  dataAlteracao: Date;
+  idComodo: number;
+  idAndar: number;
+  fotos: Array<{
+    idFoto: string;
+    urlDaFoto: string;
+  }>;
+  funcionarios: Array<{
+    funcionario: {
+      idFunc: string;
+      nomeFunc: string;
+      cargo: string;
+    };
+  }>;
+};
+
 const toRelativeUploadPath = (absolutePath: string): string =>
   path.relative(process.cwd(), absolutePath).split(path.sep).join("/");
 
@@ -1042,6 +1071,123 @@ export class ProjectService {
 
       throw new ProjectCreationError(
         "Erro desconhecido ao atualizar projeto. Tente novamente mais tarde."
+      );
+    }
+  }
+
+  /**
+   * Lista as alterações de um cômodo específico dentro de um projeto.
+   * Acessível tanto pelo Construtor (dono) quanto pelo Proprietário (vinculado).
+   *
+   * @param idProjeto   - UUID do projeto
+   * @param idComodo    - ID inteiro do cômodo
+   * @param user        - Usuário logado { id, profile }
+   * @returns {Promise<AlterationListItem[]>} - Lista de alterações normalizadas
+   * @throws {ProjectNotFoundError}     se o projeto não existir ou o usuário não tiver acesso
+   * @throws {RoomNotFoundError}        se o cômodo não existir no projeto
+   * @throws {AlterationCreationError}  em caso de erro inesperado
+   */
+  async listAlterationsByRoom(
+    idProjeto: string,
+    idComodo: number,
+    user: { id: string; profile: string }
+  ): Promise<AlterationListItem[]> {
+    try {
+      // 1. Verifica se o projeto existe e se o usuário tem permissão
+      const projeto = await prisma.projeto.findUnique({
+        where: { idProjeto },
+        select: {
+          idProjeto: true,
+          idConstrutor: true,
+          idProprietario: true,
+        },
+      });
+
+      if (!projeto) {
+        throw new ProjectNotFoundError("Projeto não encontrado.");
+      }
+
+      const temPermissao =
+        user.profile === "CONSTRUTOR"
+          ? projeto.idConstrutor === user.id
+          : user.profile === "PROPRIETARIO"
+          ? projeto.idProprietario === user.id
+          : false;
+
+      if (!temPermissao) {
+        throw new ProjectNotFoundError(
+          "Projeto não encontrado ou você não tem permissão para acessá-lo."
+        );
+      }
+
+      // 2. Verifica se o cômodo pertence ao projeto
+      const comodoExiste = await prisma.comodo.findFirst({
+        where: { idProjeto, idComodo },
+        select: { idComodo: true },
+      });
+
+      if (!comodoExiste) {
+        throw new RoomNotFoundError(
+          `O cômodo ${idComodo} não foi encontrado no projeto.`
+        );
+      }
+
+      // 3. Busca as alterações filtradas pelo cômodo, com fotos e funcionários
+      const alteracoes = await prisma.alteracao.findMany({
+        where: {
+          idProjetoComodo: idProjeto,
+          idComodo,
+        },
+        select: {
+          idAlteracao: true,
+          nomeAlteracao: true,
+          descricaoAlteracao: true,
+          area: true,
+          dataAlteracao: true,
+          idComodo: true,
+          idAndar: true,
+          fotos: {
+            select: {
+              idFoto: true,
+              urlDaFoto: true,
+            },
+          },
+          funcionarios: {
+            select: {
+              funcionario: {
+                select: {
+                  idFunc: true,
+                  nomeFunc: true,
+                  cargo: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          dataAlteracao: "asc",
+        },
+      });
+
+      return alteracoes;
+    } catch (error) {
+      if (
+        error instanceof ProjectNotFoundError ||
+        error instanceof RoomNotFoundError
+      ) {
+        throw error;
+      }
+
+      console.error("[ProjectService] Erro ao listar alterações do cômodo:", error);
+
+      if (error instanceof Error) {
+        throw new AlterationCreationError(
+          `Erro ao listar alterações: ${error.message}`
+        );
+      }
+
+      throw new AlterationCreationError(
+        "Erro desconhecido ao listar alterações. Tente novamente mais tarde."
       );
     }
   }


### PR DESCRIPTION
Adiciona listagem de alteracoes filtrada por comodo, acessivel tanto pelo Construtor (dono) quanto pelo Proprietario (vinculado ao projeto).

## ProjectService.ts
- Adiciona tipo AlterationNotFoundError
- Adiciona tipo AlterationListItem com shape completo (fotos + funcionarios)
- Implementa metodo listAlterationsByRoom(idProjeto, idComodo, user):
  * Valida permissao por perfil (CONSTRUTOR vs PROPRIETARIO)
  * Verifica existencia do comodo no projeto (404 descritivo)
  * Busca alteracoes com fotos[] e funcionarios[] via prisma.alteracao.findMany
  * Ordenadas por dataAlteracao ASC

## ProjectController.ts
- Importa AlterationNotFoundError e AlterationListItem
- Implementa listAlterationsByRoom:
  * Valida query param idComodo (obrigatorio, inteiro positivo)
  * Mapeia erros: 400 (param invalido), 401, 404, 500
  * Shape de resposta: { status, message, data: { alteracoes: [...] } }

## projectRoutes.ts
- Adiciona GET /:id/alterations (authMiddleware, sem restricao de role)
- Documentacao Swagger/OpenAPI 3.0 completa